### PR TITLE
Don't send Deathlink when killed by Deathlink

### DIFF
--- a/Polycosmos/PolycosmosEvents.lua
+++ b/Polycosmos/PolycosmosEvents.lua
@@ -41,7 +41,7 @@ last_room_completed=0
 --- variables for deathlink checks
 
 is_greece_death = false
-is_deathlink_caused_of_death = false
+is_deathlink_cause_of_death = false
 
 --variable for avoid racing problems
 

--- a/Polycosmos/PolycosmosEvents.lua
+++ b/Polycosmos/PolycosmosEvents.lua
@@ -41,7 +41,7 @@ last_room_completed=0
 --- variables for deathlink checks
 
 is_greece_death = false
-should_send_deathlink = true
+is_deathlink_caused_of_death = false
 
 --variable for avoid racing problems
 
@@ -310,9 +310,9 @@ function PolycosmosEvents.KillPlayer( message )
         CurrentRun.Hero.Health = 0
         CheckLastStand(CurrentRun.Hero, { })
     else
-        should_send_deathlink = false
+        is_deathlink_cause_of_death = true
         KillHero(CurrentRun.Hero, { }, { })
-        should_send_deathlink = true
+        is_deathlink_cause_of_death = false
     end
 end
 
@@ -323,16 +323,14 @@ StyxScribe.AddHook( PolycosmosEvents.KillPlayer, styx_scribe_recieve_prefix.."De
 function PolycosmosEvents.SendDeathlink()
     if (is_greece_death == true) then
         is_greece_death = false
-    else
+    else if (is_deathlink_cause_of_death == false)
         StyxScribe.Send(styx_scribe_send_prefix.."Zag died")
     end
 end
 
 
 ModUtil.Path.Wrap("HandleDeath", function( baseFunc, currentRun, killer, killingUnitWeapon )
-    if should_send_deathlink then
-	    PolycosmosEvents.SendDeathlink()
-    end
+	PolycosmosEvents.SendDeathlink()
 	return baseFunc(currentRun, killer, killingUnitWeapon)
 end)
 

--- a/Polycosmos/PolycosmosEvents.lua
+++ b/Polycosmos/PolycosmosEvents.lua
@@ -41,6 +41,7 @@ last_room_completed=0
 --- variables for deathlink checks
 
 is_greece_death = false
+should_send_deathlink = true
 
 --variable for avoid racing problems
 
@@ -309,7 +310,9 @@ function PolycosmosEvents.KillPlayer( message )
         CurrentRun.Hero.Health = 0
         CheckLastStand(CurrentRun.Hero, { })
     else
+        should_send_deathlink = false
         KillHero(CurrentRun.Hero, { }, { })
+        should_send_deathlink = true
     end
 end
 
@@ -327,7 +330,9 @@ end
 
 
 ModUtil.Path.Wrap("HandleDeath", function( baseFunc, currentRun, killer, killingUnitWeapon )
-	PolycosmosEvents.SendDeathlink()
+    if should_send_deathlink then
+	    PolycosmosEvents.SendDeathlink()
+    end
 	return baseFunc(currentRun, killer, killingUnitWeapon)
 end)
 


### PR DESCRIPTION
Problem:
Player A is playing ALttP. Player B is playing Super Mario 64. Player C is playing Hades. Player A dies, triggering a deathlink.

Expected:
Other Players each die once. No further deathlinks are sent.

Actual:
Zagreus's death triggers a _second_ deathlink, killing Mario a second time, sending him out of the castle. Oops! (Link is still in the Game Over screen, so nothing happens to him).


Solution:
When Zagreus is killed by a deathlink, we shouldn't be sending out a second deathlink.

